### PR TITLE
Adjust to upcoming Julia 1.12 change in implicit world age increment

### DIFF
--- a/src/runner.jl
+++ b/src/runner.jl
@@ -70,6 +70,7 @@ use_progress: Shows a progress bar
 directory: Directory to change the current process (or worker processes) to for execution.
 """
 macro execute(experiment, database, mode=SerialMode, use_progress=false, directory=pwd())
+    latestworld = isdefined(Core, :var"@latestworld") ? :(@Core.latestworld) : nothing
     quote
         if !isnothing($(esc(database)))
             $(esc(experiment)) = restore_from_db($(esc(database)), $(esc(experiment)))
@@ -87,6 +88,7 @@ macro execute(experiment, database, mode=SerialMode, use_progress=false, directo
                     if !ismissing(include_file)
                         include_file_path = joinpath(dir, include_file)
                         Base.include(Main, "$include_file_path")
+                        $latestworld
                     end
 
                     _mpi_worker_loop(runner)
@@ -133,6 +135,7 @@ macro execute(experiment, database, mode=SerialMode, use_progress=false, directo
                     end
 
                     Base.include(Main, "$include_file_path")
+                    $latestworld
                 end
 
 


### PR DESCRIPTION
In 1.12, we'll be cleaning up and making consistent when world age increment happens. This package is currently relying on implicit world age increments that may go away in 1.12. See JuliaLang/julia#56509. This PR adds appropriate annotations that the world age increment is required after the include. This PR strictly retains existing behavior. A potentially better solution may be to use invokelatest and/or move more work out of the macro, which would also allow this code to work at non-toplevel (which may nor may not be desirable).